### PR TITLE
Add new Entity API features

### DIFF
--- a/src/main/java/net/blancworks/figura/lua/api/world/entity/EntityAPI.java
+++ b/src/main/java/net/blancworks/figura/lua/api/world/entity/EntityAPI.java
@@ -69,7 +69,7 @@ public class EntityAPI {
                 set("getType", new ZeroArgFunction() {
                     @Override
                     public LuaValue call() {
-                        return LuaString.valueOf(Registry.ENTITY_TYPE.getId(targetEntity.getType()).toString());
+                        return typeString;
                     }
                 });
 

--- a/src/main/java/net/blancworks/figura/lua/api/world/entity/EntityAPI.java
+++ b/src/main/java/net/blancworks/figura/lua/api/world/entity/EntityAPI.java
@@ -1,18 +1,20 @@
 package net.blancworks.figura.lua.api.world.entity;
 
 import net.blancworks.figura.lua.LuaUtils;
+import net.blancworks.figura.lua.api.NBTAPI;
 import net.blancworks.figura.lua.api.ReadOnlyLuaTable;
 import net.blancworks.figura.lua.api.item.ItemStackAPI;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityPose;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.world.World;
-import org.luaj.vm2.LuaNumber;
-import org.luaj.vm2.LuaString;
-import org.luaj.vm2.LuaTable;
-import org.luaj.vm2.LuaValue;
+import org.luaj.vm2.*;
 import org.luaj.vm2.lib.OneArgFunction;
+import org.luaj.vm2.lib.TwoArgFunction;
 import org.luaj.vm2.lib.ZeroArgFunction;
 
 import java.util.Iterator;
@@ -48,14 +50,22 @@ public class EntityAPI {
                     @Override
                     public LuaValue call() {
                         LuaTable t = new LuaTable();
+
                         LuaValue pitch = LuaNumber.valueOf(targetEntity.pitch);
                         LuaValue yaw = LuaNumber.valueOf(targetEntity.yaw);
+                        LuaValue roll;
+                        if (targetEntity instanceof LivingEntity)
+                            roll = LuaNumber.valueOf(((LivingEntity) targetEntity).getRoll());
+                        else
+                            roll = LuaNumber.valueOf(0);
                         
                         t.set("pitch", pitch);
                         t.set("yaw", yaw);
+                        t.set("roll", roll);
 
                         t.set(1, pitch);
                         t.set(2, yaw);
+                        t.set(3, roll);
 
                         return t;
                     }
@@ -147,6 +157,50 @@ public class EntityAPI {
                             return NIL;
 
                         return LuaString.valueOf(p.name());
+                    }
+                });
+
+                set("getVehicle", new ZeroArgFunction() {
+                    @Override
+                    public LuaValue call() {
+                        if (targetEntity.getVehicle() == null) return NIL;
+
+                        Entity vehicle = targetEntity.getVehicle();
+
+                        if (vehicle instanceof LivingEntity) return new LivingEntityAPI.LivingEntityAPITable<>((LivingEntity) vehicle);
+
+                        return new EntityLuaAPITable<>(vehicle);
+                    }
+                });
+
+                set("isGrounded", new ZeroArgFunction() {
+                    @Override
+                    public LuaValue call() {
+                        return LuaBoolean.valueOf(targetEntity.isOnGround());
+                    }
+                });
+
+                set("getNbtValue", new OneArgFunction() {
+                    @Override
+                    public LuaValue call(LuaValue arg) {
+                        String pathArg = arg.checkjstring();
+
+                        String[] path = pathArg.split("\\.");
+
+                        CompoundTag tag = new CompoundTag();
+                        targetEntity.toTag(tag);
+
+                        Tag current = null;
+                        for (String key : path) {
+                            if (current == null)
+                                current = tag.get(key);
+                            else if (current instanceof CompoundTag)
+                                current = ((CompoundTag)current).get(key);
+                        }
+
+                        if (current == null) return NIL;
+
+                        return NBTAPI.fromTag(current);
                     }
                 });
                 

--- a/src/main/java/net/blancworks/figura/lua/api/world/entity/EntityAPI.java
+++ b/src/main/java/net/blancworks/figura/lua/api/world/entity/EntityAPI.java
@@ -4,12 +4,14 @@ import net.blancworks.figura.lua.LuaUtils;
 import net.blancworks.figura.lua.api.NBTAPI;
 import net.blancworks.figura.lua.api.ReadOnlyLuaTable;
 import net.blancworks.figura.lua.api.item.ItemStackAPI;
+import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityPose;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.world.World;
 import org.luaj.vm2.*;
@@ -53,19 +55,12 @@ public class EntityAPI {
 
                         LuaValue pitch = LuaNumber.valueOf(targetEntity.pitch);
                         LuaValue yaw = LuaNumber.valueOf(targetEntity.yaw);
-                        LuaValue roll;
-                        if (targetEntity instanceof LivingEntity)
-                            roll = LuaNumber.valueOf(((LivingEntity) targetEntity).getRoll());
-                        else
-                            roll = LuaNumber.valueOf(0);
                         
                         t.set("pitch", pitch);
                         t.set("yaw", yaw);
-                        t.set("roll", roll);
 
                         t.set(1, pitch);
                         t.set(2, yaw);
-                        t.set(3, roll);
 
                         return t;
                     }
@@ -74,7 +69,7 @@ public class EntityAPI {
                 set("getType", new ZeroArgFunction() {
                     @Override
                     public LuaValue call() {
-                        return typeString;
+                        return LuaString.valueOf(Registry.ENTITY_TYPE.getId(targetEntity.getType()).toString());
                     }
                 });
 
@@ -167,9 +162,9 @@ public class EntityAPI {
 
                         Entity vehicle = targetEntity.getVehicle();
 
-                        if (vehicle instanceof LivingEntity) return new LivingEntityAPI.LivingEntityAPITable<>((LivingEntity) vehicle);
+                        if (vehicle instanceof LivingEntity) return new LivingEntityAPI.LivingEntityAPITable<>((LivingEntity) vehicle).getTable();
 
-                        return new EntityLuaAPITable<>(vehicle);
+                        return new EntityLuaAPITable<>(vehicle).getTable();
                     }
                 });
 
@@ -190,12 +185,13 @@ public class EntityAPI {
                         CompoundTag tag = new CompoundTag();
                         targetEntity.toTag(tag);
 
-                        Tag current = null;
+                        Tag current = tag;
                         for (String key : path) {
                             if (current == null)
                                 current = tag.get(key);
                             else if (current instanceof CompoundTag)
                                 current = ((CompoundTag)current).get(key);
+                            else current = null;
                         }
 
                         if (current == null) return NIL;

--- a/src/main/java/net/blancworks/figura/lua/api/world/entity/LivingEntityAPI.java
+++ b/src/main/java/net/blancworks/figura/lua/api/world/entity/LivingEntityAPI.java
@@ -75,6 +75,7 @@ public class LivingEntityAPI {
                     int i = 1;
                     for (StatusEffectInstance inst : targetEntity.getStatusEffects()) {
                         effects.set(i, LuaString.valueOf(Registry.STATUS_EFFECT.getId(inst.getEffectType()).toString()));
+                        i++;
                     }
 
                     return effects;

--- a/src/main/java/net/blancworks/figura/lua/api/world/entity/LivingEntityAPI.java
+++ b/src/main/java/net/blancworks/figura/lua/api/world/entity/LivingEntityAPI.java
@@ -1,9 +1,15 @@
 package net.blancworks.figura.lua.api.world.entity;
 
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.effect.StatusEffect;
+import net.minecraft.entity.effect.StatusEffectInstance;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
 import org.luaj.vm2.LuaNumber;
+import org.luaj.vm2.LuaString;
 import org.luaj.vm2.LuaTable;
 import org.luaj.vm2.LuaValue;
+import org.luaj.vm2.lib.OneArgFunction;
 import org.luaj.vm2.lib.ZeroArgFunction;
 
 public class LivingEntityAPI {
@@ -18,6 +24,13 @@ public class LivingEntityAPI {
         @Override
         public LuaTable getTable() {
             LuaTable superTable = super.getTable();
+
+            superTable.set("getBodyYaw", new ZeroArgFunction() {
+                @Override
+                public LuaValue call() {
+                    return LuaNumber.valueOf(targetEntity.bodyYaw);
+                }
+            });
             
             superTable.set("getHealth", new ZeroArgFunction() {
                 @Override
@@ -51,6 +64,48 @@ public class LivingEntityAPI {
                 @Override
                 public LuaValue call() {
                     return LuaNumber.valueOf(targetEntity.deathTime);
+                }
+            });
+
+            superTable.set("getStatusEffectTypes", new ZeroArgFunction() {
+                @Override
+                public LuaValue call() {
+                    LuaTable effects = new LuaTable();
+
+                    int i = 1;
+                    for (StatusEffectInstance inst : targetEntity.getStatusEffects()) {
+                        effects.set(i, LuaString.valueOf(Registry.STATUS_EFFECT.getId(inst.getEffectType()).toString()));
+                    }
+
+                    return effects;
+                }
+            });
+
+            superTable.set("getStatusEffect", new OneArgFunction() {
+                @Override
+                public LuaValue call(LuaValue arg) {
+                    Identifier effectId = Identifier.tryParse(arg.checkjstring());
+                    if(effectId == null)
+                        return NIL;
+
+                    StatusEffect statusEffect = Registry.STATUS_EFFECT.get(effectId);
+
+                    if (!targetEntity.hasStatusEffect(statusEffect))
+                        return NIL;
+
+                    LuaTable effect = new LuaTable();
+                    StatusEffectInstance instance = targetEntity.getStatusEffect(statusEffect);
+                    effect.set("duration", instance.getDuration());
+                    effect.set("amplifier", instance.getAmplifier());
+
+                    return effect;
+                }
+            });
+
+            superTable.set("isSneaky", new ZeroArgFunction() {
+                @Override
+                public LuaValue call() {
+                    return LuaNumber.valueOf(targetEntity.isSneaky());
                 }
             });
             

--- a/src/main/java/net/blancworks/figura/lua/api/world/entity/PlayerEntityAPI.java
+++ b/src/main/java/net/blancworks/figura/lua/api/world/entity/PlayerEntityAPI.java
@@ -8,9 +8,11 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Identifier;
 import net.minecraft.world.World;
+import org.luaj.vm2.LuaNumber;
 import org.luaj.vm2.LuaTable;
 import org.luaj.vm2.LuaValue;
 import org.luaj.vm2.lib.OneArgFunction;
+import org.luaj.vm2.lib.ZeroArgFunction;
 
 public class PlayerEntityAPI {
 
@@ -63,6 +65,34 @@ public class PlayerEntityAPI {
                     
                     LuaTable getItemRepresentation = ItemStackAPI.getTable(targetStack);
                     return getItemRepresentation;
+                }
+            });
+
+            superTable.set("getFood", new ZeroArgFunction() {
+                @Override
+                public LuaValue call() {
+                    return LuaNumber.valueOf(targetEntity.getHungerManager().getFoodLevel());
+                }
+            });
+
+            superTable.set("getSaturation", new ZeroArgFunction() {
+                @Override
+                public LuaValue call() {
+                    return LuaNumber.valueOf(targetEntity.getHungerManager().getSaturationLevel());
+                }
+            });
+
+            superTable.set("getExperienceProgress", new ZeroArgFunction() {
+                @Override
+                public LuaValue call() {
+                    return LuaNumber.valueOf(targetEntity.experienceProgress);
+                }
+            });
+
+            superTable.set("getExperienceLevel", new ZeroArgFunction() {
+                @Override
+                public LuaValue call() {
+                    return LuaNumber.valueOf(targetEntity.experienceLevel);
                 }
             });
             


### PR DESCRIPTION
The following PR adds the following

# **Entity API Features**
## **`Entity/LivingEntity getVehicle()`**
Returns an `Entity` or `LivingEntity` table for the entity being ridden by the current entity, or `nil` if none.
## **`boolean isGrounded()`**
Returns whether the entity is on the ground.
## **EXPERIMENTAL - `any getNbtValue(string)`**
Returns a value of no specific type, based on the NBT path specified. 
An example of an NBT path would be `"abilities.flying"` for whether a player is flying.
Some values may not be properly synced to the client, and this function can have some overhead. Use with care.

# **LivingEntity API Features**
## **`number getBodyYaw()`**
Gets the yaw of the entity's body, which is often slightly offset from the head yaw.
## **`{string ... } getStatusEffectTypes()`**
Returns a list of `string` ids for the current status effects the entity has. 
An example of a status effect id is `"minecraft:fire_resistance"`.
## **`{amplifier, duration} getStatusEffect(string)`**
If the entity has the specified status effect id, this function returns a table containing the `amplifier` and `duration` (in ticks) of the status effect.
If the entity does not have the specified effect, this will return `nil`.
## **`boolean isSneaky()`**
Returns whether the entity is "sneaky". For players, this returns true if the player is crouched.

# **PlayerEntity API Features**
## **`number getFood()`**
Returns the player's food value. 
Ranges from 0 to 20.
## **`number getSaturation()`**
Returns the player's saturation value. 
Ranges from 0.0 to 20.0.
## **`number getExperienceProgress()`**
Returns the progress the player has made to the next experience level, which is displayed as the experience bar. 
Ranges from 0.0 to 1.0.
## **`number getExperienceLevel()`**
Returns the player's current experience level.