### PR TITLE
fix a crash when reloading model

### DIFF
--- a/src/main/java/net/blancworks/figura/gui/FiguraGuiScreen.java
+++ b/src/main/java/net/blancworks/figura/gui/FiguraGuiScreen.java
@@ -214,7 +214,7 @@ public class FiguraGuiScreen extends Screen {
             modelFileList.reloadFilters();
 
             //reload data
-            if (PlayerDataManager.localPlayer.model != null) {
+            if (PlayerDataManager.localPlayer != null && PlayerDataManager.localPlayer.model != null) {
                 if (PlayerDataManager.lastLoadedFileName == null)
                     nameText = null;
                 modelComplexityText = new TranslatableText("gui.figura.complexity", PlayerDataManager.localPlayer.model.getRenderComplexity());


### PR DESCRIPTION
happened when i reloaded my model from the figura server.
before i reloaded my model, i also got a lot of `[main/ERROR]: Failed to load texture null` in my logs, with a blank texture on it.