### PR TITLE
Add a "meta" api

### DIFF
--- a/src/main/java/net/blancworks/figura/lua/FiguraLuaManager.java
+++ b/src/main/java/net/blancworks/figura/lua/FiguraLuaManager.java
@@ -2,6 +2,7 @@ package net.blancworks.figura.lua;
 
 import net.blancworks.figura.PlayerData;
 import net.blancworks.figura.lua.api.LuaEvent;
+import net.blancworks.figura.lua.api.MetaAPI;
 import net.blancworks.figura.lua.api.ReadOnlyLuaTable;
 import net.blancworks.figura.lua.api.VectorAPI;
 import net.blancworks.figura.lua.api.model.*;
@@ -58,6 +59,7 @@ public class FiguraLuaManager {
         apiSuppliers.put(ItemModelAPI.getID(), ItemModelAPI::getForScript);
         apiSuppliers.put(VectorAPI.getID(), VectorAPI::getForScript);
         apiSuppliers.put(SoundAPI.getID(), SoundAPI::getForScript);
+        apiSuppliers.put(MetaAPI.getID(), MetaAPI::getForScript);
     }
 
     public static void registerEvents(){

--- a/src/main/java/net/blancworks/figura/lua/api/MetaAPI.java
+++ b/src/main/java/net/blancworks/figura/lua/api/MetaAPI.java
@@ -1,0 +1,81 @@
+package net.blancworks.figura.lua.api;
+
+import net.blancworks.figura.lua.CustomScript;
+import net.blancworks.figura.trust.PlayerTrustManager;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.util.math.Vector3f;
+import net.minecraft.client.util.math.Vector4f;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Vec2f;
+import net.minecraft.world.World;
+import org.luaj.vm2.LuaBoolean;
+import org.luaj.vm2.LuaTable;
+import org.luaj.vm2.LuaValue;
+import org.luaj.vm2.lib.OneArgFunction;
+import org.luaj.vm2.lib.ThreeArgFunction;
+import org.luaj.vm2.lib.TwoArgFunction;
+import org.luaj.vm2.lib.ZeroArgFunction;
+
+import java.util.ArrayList;
+
+public class MetaAPI {
+    public static Identifier getID() {
+        return new Identifier("default", "meta");
+    }
+
+    public static ReadOnlyLuaTable getForScript(CustomScript script) {
+        ScriptLocalAPITable producedTable = new ScriptLocalAPITable(script, new LuaTable() {{
+            set("getInitLimit", new ZeroArgFunction() {
+                @Override
+                public LuaValue call() {
+                    return LuaValue.valueOf(script.playerData.getTrustContainer().getIntSetting(PlayerTrustManager.MAX_INIT_ID));
+                }
+            });
+            
+            set("getTickLimit", new ZeroArgFunction() {
+                @Override
+                public LuaValue call() {
+                    return LuaValue.valueOf(script.playerData.getTrustContainer().getIntSetting(PlayerTrustManager.MAX_TICK_ID));
+                }
+            });
+    
+            set("getRenderLimit", new ZeroArgFunction() {
+                @Override
+                public LuaValue call() {
+                    return LuaValue.valueOf(script.playerData.getTrustContainer().getIntSetting(PlayerTrustManager.MAX_RENDER_ID));
+                }
+            });
+    
+            set("getCanModifyVanilla", new ZeroArgFunction() {
+                @Override
+                public LuaValue call() {
+                    return LuaValue.valueOf(script.playerData.getTrustContainer().getBoolSetting(PlayerTrustManager.ALLOW_VANILLA_MOD_ID));
+                }
+            });
+    
+            set("getComplexityLimit", new ZeroArgFunction() {
+                @Override
+                public LuaValue call() {
+                    return LuaValue.valueOf(script.playerData.getTrustContainer().getIntSetting(PlayerTrustManager.MAX_COMPLEXITY_ID));
+                }
+            });
+    
+            set("getParticleLimit", new ZeroArgFunction() {
+                @Override
+                public LuaValue call() {
+                    return LuaValue.valueOf(script.playerData.getTrustContainer().getIntSetting(PlayerTrustManager.MAX_PARTICLES_ID));
+                }
+            });
+            
+            set("getSoundLimit", new ZeroArgFunction() {
+                @Override
+                public LuaValue call() {
+                    return LuaValue.valueOf(script.playerData.getTrustContainer().getIntSetting(PlayerTrustManager.MAX_SOUND_EFFECTS_ID));
+                }
+            });
+        }});
+    
+        return producedTable;
+    }
+}

--- a/src/main/java/net/blancworks/figura/lua/api/MetaAPI.java
+++ b/src/main/java/net/blancworks/figura/lua/api/MetaAPI.java
@@ -2,22 +2,10 @@ package net.blancworks.figura.lua.api;
 
 import net.blancworks.figura.lua.CustomScript;
 import net.blancworks.figura.trust.PlayerTrustManager;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.util.math.Vector3f;
-import net.minecraft.client.util.math.Vector4f;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.math.MathHelper;
-import net.minecraft.util.math.Vec2f;
-import net.minecraft.world.World;
-import org.luaj.vm2.LuaBoolean;
 import org.luaj.vm2.LuaTable;
 import org.luaj.vm2.LuaValue;
-import org.luaj.vm2.lib.OneArgFunction;
-import org.luaj.vm2.lib.ThreeArgFunction;
-import org.luaj.vm2.lib.TwoArgFunction;
 import org.luaj.vm2.lib.ZeroArgFunction;
-
-import java.util.ArrayList;
 
 public class MetaAPI {
     public static Identifier getID() {


### PR DESCRIPTION
Adds a small API for getting the various limitations currently imposed on a script.

The most useful one here is likely `meta.getCanModifyVanilla()` as it would allow for different displays/behavior if you can't remove/manipulate the default model, so your avatar doesn't look like a weird mess to people who have you un-trusted. The rest are mainly provided for completeness, although I'm sure someone will find it useful.