### PR TITLE
Singleplayer pause screen bugfix

### DIFF
--- a/src/main/java/net/blancworks/figura/lua/CustomScript.java
+++ b/src/main/java/net/blancworks/figura/lua/CustomScript.java
@@ -261,6 +261,10 @@ public class CustomScript extends FiguraAsset {
     //Called whenever the global tick event happens
     public void tick() {
 
+        if (MinecraftClient.getInstance().isPaused()) {
+            return;
+        };
+
         if (particleSpawnCount > 0)
             particleSpawnCount = MathHelper.clamp(particleSpawnCount - ((1 / 20f) * playerData.getTrustContainer().getIntSetting(PlayerTrustManager.MAX_PARTICLES_ID)), 0, 999);
         if (soundSpawnCount > 0)
@@ -276,6 +280,11 @@ public class CustomScript extends FiguraAsset {
 
     //Called whenever the game renders a new frame with this avatar in view
     public void render(float deltaTime) {
+
+        if (MinecraftClient.getInstance().isPaused()) {
+            return;
+        };
+
         //Don't render if the script is doing something else still
         //Prevents threading memory errors and also ensures that "long" ticks and events and such are penalized.
         if (tickLuaEvent == null || currTask == null || !currTask.isDone())


### PR DESCRIPTION
render() and tick() functions were called while a singleplayer game was paused, resulting in unexpected behavior. pr is a fix.