### PR TITLE
have script name in errors be the avatar name instead of 'main'

### DIFF
--- a/src/main/java/net/blancworks/figura/PlayerData.java
+++ b/src/main/java/net/blancworks/figura/PlayerData.java
@@ -132,11 +132,11 @@ public class PlayerData {
      */
     public void readNbt(CompoundTag nbt) {
         playerId = nbt.getUuid("id");
-        
+
         model = null;
         texture = null;
         script = null;
-        
+
         extraTextures.clear();
 
         try {
@@ -231,8 +231,6 @@ public class PlayerData {
     public void tick() {
         if (this.isInvalidated)
             PlayerDataManager.clearPlayer(playerId);
-        
-        
         vanillaModel = ((PlayerEntityRenderer) MinecraftClient.getInstance().getEntityRenderDispatcher().getRenderer(MinecraftClient.getInstance().player)).getModel();
         lastEntity = MinecraftClient.getInstance().world.getPlayerByUuid(this.playerId);
         FiguraMod.currentPlayer = (AbstractClientPlayerEntity) lastEntity;
@@ -254,9 +252,6 @@ public class PlayerData {
     }
 
     public void loadFromNbt(CompoundTag tag) {
-        
-        
-        
         this.readNbt(tag);
         getFileSize();
     }
@@ -267,7 +262,6 @@ public class PlayerData {
 
     //Saves this playerdata to the cache.
     public void saveToCache(UUID id) {
-        
         //We run this as a task to make sure all the previous load operations are done (since those are all also tasks)
         FiguraMod.doTask(() -> {
             Path destinationPath = FiguraMod.getModContentDirectory().resolve("cache");

--- a/src/main/java/net/blancworks/figura/lua/CustomScript.java
+++ b/src/main/java/net/blancworks/figura/lua/CustomScript.java
@@ -110,7 +110,7 @@ public class CustomScript extends FiguraAsset {
         try {
             //Load the script source, name defaults to "main" for scripts for other players.
             String scriptName = data == PlayerDataManager.localPlayer
-                ? PlayerDataManager.localPlayer.
+                ? PlayerDataManager.localPlayer.loadedName
                 : "main";
             LuaValue chunk = FiguraLuaManager.modGlobals.load(source, scriptName, scriptGlobals);
 

--- a/src/main/java/net/blancworks/figura/lua/CustomScript.java
+++ b/src/main/java/net/blancworks/figura/lua/CustomScript.java
@@ -66,7 +66,7 @@ public class CustomScript extends FiguraAsset {
 
     public float particleSpawnCount = 0;
     public float soundSpawnCount = 0;
-    
+
     public Float customShadowSize = null;
 
     public CustomScript() {
@@ -108,8 +108,11 @@ public class CustomScript extends FiguraAsset {
         setupGlobals();
 
         try {
-            //Load the script source.
-            LuaValue chunk = FiguraLuaManager.modGlobals.load(source, "main", scriptGlobals);
+            //Load the script source, name defaults to "main" for scripts for other players.
+            String scriptName = data == PlayerDataManager.localPlayer
+                ? PlayerDataManager.localPlayer.
+                : "main";
+            LuaValue chunk = FiguraLuaManager.modGlobals.load(source, scriptName, scriptGlobals);
 
             instructionCapFunction = new ZeroArgFunction() {
                 public LuaValue call() {
@@ -218,7 +221,7 @@ public class CustomScript extends FiguraAsset {
                     loadError = true;
                     error("Can't use global table metatable on other tables!");
                 }
-                
+
                 if (value.isfunction() && key.isstring()) {
                     String funcName = key.checkjstring();
                     LuaFunction func = value.checkfunction();


### PR DESCRIPTION
easier to debug stuff if every script isnt just called "main" regardless of avatar

example script cool_avatar/script.lua
```lua
error("scary error")
```

before:
`main:1 scary error`

after (for local avatars only):
`cool_avatar:1 scary error`